### PR TITLE
Refactored HResult to make a little more sense

### DIFF
--- a/sample/src/lib.rs
+++ b/sample/src/lib.rs
@@ -3,9 +3,11 @@
 use hex_literal::hex;
 
 use vbs_enclave::types::VTL0Ptr;
+use vbs_enclave::{HResult, HResultError, HResultSuccess, NativeHResult};
 use vbs_enclave::winenclave::{
-    HResult, HResultError, HResultSuccess, ImageEnclaveConfig, NativeHResult,
-    IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE, IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE,
+    ImageEnclaveConfig,
+    IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE,
+    IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE,
 };
 
 #[cfg(debug_assertions)]
@@ -58,17 +60,17 @@ extern "C" fn my_enclave_function(param: VTL0Ptr<MyEnclaveParams>) -> NativeHRes
     // };
 
     match my_enclave_function_safe(&mut params) {
-        Ok(s) => s as NativeHResult,
+        Ok(s) => s,
         Err(e) => e,
     }
 }
 
 fn my_enclave_function_safe(params: &mut VTL1MyEnclaveParams) -> HResult {
     if params.a + params.b != params.c {
-        return Err(HResultError::InvalidState as NativeHResult);
+        return Err(HResultError::InvalidState as _);
     }
 
     *params.e = params.d.iter().sum();
 
-    Ok(HResultSuccess::Ok)
+    Ok(HResultSuccess::Ok as _)
 }

--- a/sample/src/params.rs
+++ b/sample/src/params.rs
@@ -1,5 +1,6 @@
 extern crate alloc;
 use alloc::boxed::Box;
+use vbs_enclave::NativeHResult;
 use vbs_enclave::types::{
     VTL0Array, VTL0MutPtr, VTL0Ptr, VTL1Clonable, VTL1ClonableArray, VTL1MutPtr,
 };
@@ -38,7 +39,7 @@ pub struct VTL1MyEnclaveParams {
 }
 
 impl TryFrom<VTL0Ptr<MyEnclaveParams>> for VTL1MyEnclaveParams {
-    type Error = u32;
+    type Error = NativeHResult;
     fn try_from(value: VTL0Ptr<MyEnclaveParams>) -> Result<Self, Self::Error> {
         let vtl1_clone = value.clone_into_vtl1()?;
         let c: u32 = vtl1_clone.c.clone_into_vtl1()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,43 @@
 use core::ffi::c_void;
 use core::ptr;
 
+pub type NativeHResult = i32;
+pub type HResult = Result<NativeHResult, NativeHResult>;
+
+#[repr(i32)]
+pub enum HResultSuccess {
+    Ok = 0,
+}
+
+impl TryFrom<NativeHResult> for HResultSuccess {
+    type Error = NativeHResult;
+    fn try_from(value: NativeHResult) -> Result<Self, Self::Error> {
+        match value {
+            x if x == HResultSuccess::Ok as _ => Ok(HResultSuccess::Ok),
+            x => Err(x),
+        }
+    }
+}
+
+#[repr(i32)]
+pub enum HResultError {
+    InvalidArgument = 0x8007_0057u32 as i32,
+    InvalidState = 0x8007_139fu32 as i32,
+    Unexpected = 0x8000_ffffu32 as i32,
+}
+
+impl TryFrom<NativeHResult> for HResultError {
+    type Error = NativeHResult;
+    fn try_from(value: NativeHResult) -> Result<Self, Self::Error> {
+        match value {
+            x if x == HResultError::InvalidArgument as _ => Ok(HResultError::InvalidArgument),
+            x if x == HResultError::InvalidState as _ => Ok(HResultError::InvalidState),
+            x if x == HResultError::Unexpected as _ => Ok(HResultError::Unexpected),
+            x => Err(x),
+        }
+    }
+}
+
 mod allocator;
 pub mod types;
 pub mod winenclave;

--- a/src/types.rs
+++ b/src/types.rs
@@ -4,7 +4,8 @@ use alloc::{boxed::Box, slice};
 
 use crate::{
     is_valid_vtl0,
-    winenclave::{HResultError, NativeHResult},
+    HResultError,
+    NativeHResult
 };
 
 pub trait VTL1Clonable<T: Copy> {


### PR DESCRIPTION
`HRESULT` is actually an `i32`, so this updated the `NativeHResult` type to reflect that.

Additionally, this change updates `HResult` to be a `Result<NativeHResult, NativeHResult>` instead of an `HResultSuccess` or `NativeHResult`, which I think just makes it cleaner.

Finally, the `HResultSuccess` and `HResultError` enums were updated to use `repr(i32)` and `TryFrom` implementations to convert from `NativeHResult` to the appropriate enum variant that might be useful for readability when writing code that uses common return codes.