### PR TITLE
Implement unsafe memory accessors in Windows SDK 10.0.26100.3624

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,12 @@ publish = false
 [lib]
 test = false
 
+[features]
+zerocopy = ["dep:zerocopy"]
+
 [dependencies]
 thiserror = { version = "2.0", default-features = false }
+zerocopy = { version = "0.8.24", optional = true }
 
 [dependencies.windows-sys]
 version = "0.59.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Prior to building, follow the steps in the [VBS Enclaves Development Guide](http
 
 You will probably want to run the sample on a test system, since it requires test signing. When you set up your test system, ensure that VBS is enabled. The instructions below work for a Hyper-V VM:
 
-##### Generation 1 VM
+##### Generation 1 VM (not recommended, you should use gen2)
 On your host system, in an administrator prompt, run:
 ```powershell
 Set-VMProcessor -VmName "My VM Name" -ExposeVirtualizationExtensions $true
@@ -55,13 +55,13 @@ Once you have a test signing certificate created and have enabled test signing o
 #### Strict Memory
 As of Windows SDK 10.0.26100.3624, VBS enclaves support a strict memory policy that prevents the enclave from directly accessing VTL0 memory. This removes a lot of attack surface that can result from not validating pointers before accessing them in the enclave.
 
-To enable this policy in the enclave, use the `strict_memory` feature; this is reflected in the build instructions below, but if you do not specify it, it will default to the old, insecure, policy.
+The `strict_memory` feature enables this by default. If you want to build it with the old, insecure, policy then you must specify `--no-default-flags` with `cargo build`.
 
 #### Debug build
 
 ```powershell
 cd sample
-cargo build --features strict_memory
+cargo build
 veiid.exe .\target\debug\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name
@@ -72,7 +72,7 @@ signtool.exe sign /ph /fd SHA256 /n "MyTestEnclaveCert" target\debug\sample_vbs_
 
 ```powershell
 cd sample
-cargo build -r --features strict_memory
+cargo build -r
 veiid.exe .\target\release\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project is the result of a Microsoft Offensive Research & Security Engineer
 - [Rustlang](https://www.rust-lang.org/tools/install) 1.86.0-nightly
 - Cargo
 - [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
-- [Windows 11 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) (10.0.22621.3233 or later)
+- [Windows 11 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) (10.0.26100.3624 or later)
 
 It was tested on x86_64, but will probably build for arm64 with no issues.
 
@@ -30,14 +30,15 @@ Prior to building, follow the steps in the [VBS Enclaves Development Guide](http
 
 You will probably want to run the sample on a test system, since it requires test signing. When you set up your test system, ensure that VBS is enabled. The instructions below work for a Hyper-V VM:
 
+##### Generation 1 VM
 On your host system, in an administrator prompt, run:
 ```powershell
 Set-VMProcessor -VmName "My VM Name" -ExposeVirtualizationExtensions $true
 ```
-
+##### Generation 1 and 2 VMs
 On your test system VM, run:
 ```powershell
-bcdedit /set testsigning on
+bcdedit /set testsigning on # you will need to disable Secure Boot on Generation 2 VMs first
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard" /v "EnableVirtualizationBasedSecurity" /t REG_DWORD /d 1 /f
 Restart-Computer
 ```
@@ -51,11 +52,16 @@ Import-Certificate C:\enclave.cer
 
 Once you have a test signing certificate created and have enabled test signing on the system that will run the example enclave, you can build the enclave itself from the Visual Studio command prompt:
 
+#### Strict Memory
+As of Windows SDK 10.0.26100.3624, VBS enclaves support a strict memory policy that prevents the enclave from directly accessing VTL0 memory. This removes a lot of attack surface that can result from not validating pointers before accessing them in the enclave.
+
+To enable this policy in the enclave, use the `strict_memory` feature; this is reflected in the build instructions below, but if you do not specify it, it will default to the old, insecure, policy.
+
 #### Debug build
 
 ```powershell
 cd sample
-cargo build
+cargo build --features strict_memory
 veiid.exe .\target\debug\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name
@@ -66,7 +72,7 @@ signtool.exe sign /ph /fd SHA256 /n "MyTestEnclaveCert" target\debug\sample_vbs_
 
 ```powershell
 cd sample
-cargo build -r
+cargo build -r --features strict_memory
 veiid.exe .\target\release\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -16,6 +16,7 @@ panic = "abort"
 panic = "abort"
 
 [features]
+default = ["strict_memory"]
 strict_memory = []
 
 [dependencies]

--- a/sample/Cargo.toml
+++ b/sample/Cargo.toml
@@ -15,8 +15,12 @@ panic = "abort"
 [profile.dev]
 panic = "abort"
 
+[features]
+strict_memory = []
+
 [dependencies]
-vbs-enclave = { path = ".." }
+vbs-enclave = { path = "..", features=["zerocopy"] }
+zerocopy = { version = "0.8.24", features=["derive"] }
 hex-literal = "0.4.1"
 spin = "0.9.8"
 

--- a/sample/README.md
+++ b/sample/README.md
@@ -50,7 +50,7 @@ Prior to building, follow the steps in the [VBS Enclaves Development Guide](http
 
 You will probably want to run the sample on a test system, since it requires test signing. When you set up your test system, ensure that VBS is enabled. The instructions below work for a Hyper-V VM:
 
-##### Generation 1 VM
+##### Generation 1 VM (not recommended, you should use gen2)
 On your host system, in an administrator prompt, run:
 ```powershell
 Set-VMProcessor -VmName "My VM Name" -ExposeVirtualizationExtensions $true
@@ -75,13 +75,13 @@ Once you have a test signing certificate created and have enabled test signing o
 #### Strict Memory
 As of Windows SDK 10.0.26100.3624, VBS enclaves support a strict memory policy that prevents the enclave from directly accessing VTL0 memory. This removes a lot of attack surface that can result from not validating pointers before accessing them in the enclave.
 
-To enable this policy in the enclave, use the `strict_memory` feature; this is reflected in the build instructions below, but if you do not specify it, it will default to the old, insecure, policy.
+The `strict_memory` feature enables this by default. If you want to build it with the old, insecure, policy then you must specify `--no-default-flags` with `cargo build`.
 
 #### Debug build
 
 ```powershell
 cd sample
-cargo build --features strict_memory
+cargo build
 veiid.exe .\target\debug\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name
@@ -92,7 +92,7 @@ signtool.exe sign /ph /fd SHA256 /n "MyTestEnclaveCert" target\debug\sample_vbs_
 
 ```powershell
 cd sample
-cargo build -r --features strict_memory
+cargo build -r
 veiid.exe .\target\release\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name

--- a/sample/README.md
+++ b/sample/README.md
@@ -29,7 +29,7 @@ Using these routines, the host process then performs the following actions:
 - [Rustlang](https://www.rust-lang.org/tools/install) 1.86.0-nightly
 - Cargo
 - [Visual Studio 2022](https://visualstudio.microsoft.com/downloads/)
-- [Windows 11 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) (10.0.22621.3233 or later)
+- [Windows 11 SDK](https://developer.microsoft.com/en-us/windows/downloads/windows-sdk/) (10.0.26100.3624 or later)
 
 It was tested on x86_64, but will probably build for arm64 with no issues.
 
@@ -50,14 +50,15 @@ Prior to building, follow the steps in the [VBS Enclaves Development Guide](http
 
 You will probably want to run the sample on a test system, since it requires test signing. When you set up your test system, ensure that VBS is enabled. The instructions below work for a Hyper-V VM:
 
+##### Generation 1 VM
 On your host system, in an administrator prompt, run:
 ```powershell
 Set-VMProcessor -VmName "My VM Name" -ExposeVirtualizationExtensions $true
 ```
-
+##### Generation 1 and 2 VMs
 On your test system VM, run:
 ```powershell
-bcdedit /set testsigning on
+bcdedit /set testsigning on # you will need to disable Secure Boot on Generation 2 VMs first
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\DeviceGuard" /v "EnableVirtualizationBasedSecurity" /t REG_DWORD /d 1 /f
 Restart-Computer
 ```
@@ -71,11 +72,16 @@ Import-Certificate C:\enclave.cer
 
 Once you have a test signing certificate created and have enabled test signing on the system that will run the example enclave, you can build the enclave itself from the Visual Studio command prompt:
 
+#### Strict Memory
+As of Windows SDK 10.0.26100.3624, VBS enclaves support a strict memory policy that prevents the enclave from directly accessing VTL0 memory. This removes a lot of attack surface that can result from not validating pointers before accessing them in the enclave.
+
+To enable this policy in the enclave, use the `strict_memory` feature; this is reflected in the build instructions below, but if you do not specify it, it will default to the old, insecure, policy.
+
 #### Debug build
 
-```
+```powershell
 cd sample
-cargo build
+cargo build --features strict_memory
 veiid.exe .\target\debug\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name
@@ -84,9 +90,9 @@ signtool.exe sign /ph /fd SHA256 /n "MyTestEnclaveCert" target\debug\sample_vbs_
 
 #### Release build
 
-```
+```powershell
 cd sample
-cargo build -r
+cargo build -r --features strict_memory
 veiid.exe .\target\release\sample_vbs_enclave_rs.dll
 
 # Replace "MyTestEnclaveCert" with your test signing certificate's name

--- a/sample/src/ffi.rs
+++ b/sample/src/ffi.rs
@@ -1,5 +1,3 @@
-use core::ffi::c_void;
-
 use crate::params::{DecryptDataParams, GenerateReportParams, NewKeypairParams};
 use crate::{
     decrypt_data_internal, generate_report_internal, new_keypair_internal,
@@ -7,21 +5,26 @@ use crate::{
 };
 use alloc::vec::Vec;
 use hex_literal::hex;
-use vbs_enclave::enclaveapi::{call_enclave, EnclaveRoutineInvocation};
 use vbs_enclave::error::{EnclaveError, HRESULT, S_OK};
 use vbs_enclave::is_valid_vtl0;
-use vbs_enclave::types::LPENCLAVE_ROUTINE;
 use vbs_enclave::winenclave::{
-    ImageEnclaveConfig, IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE, IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE,
+    copy_into_enclave, copy_out_of_enclave, copy_slice_into_enclave, copy_slice_out_of_enclave, ImageEnclaveConfig, IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE, IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE
 };
 
 // You should only enable debug in debug builds, or it can allow someone to
 // access your enclave in VTL0.
 // See: https://learn.microsoft.com/en-us/windows/win32/trusted-execution/vbs-enclaves-dev-guide#step-4-debugging-vbs-enclaves
 #[cfg(debug_assertions)]
-const ENCLAVE_CONFIG_POLICY_FLAGS: u32 = vbs_enclave::winenclave::IMAGE_ENCLAVE_POLICY_DEBUGGABLE;
+const DEBUGGABLE: u32 = vbs_enclave::winenclave::IMAGE_ENCLAVE_POLICY_DEBUGGABLE;
 #[cfg(not(debug_assertions))]
-const ENCLAVE_CONFIG_POLICY_FLAGS: u32 = 0;
+const DEBUGGABLE: u32 = 0;
+
+#[cfg(feature = "strict_memory")]
+const STRICT_MEMORY: u32 = vbs_enclave::winenclave::IMAGE_ENCLAVE_POLICY_STRICT_MEMORY;
+#[cfg(not(feature = "strict_memory"))]
+const STRICT_MEMORY: u32 = 0;
+
+const ENCLAVE_CONFIG_POLICY_FLAGS: u32 = DEBUGGABLE | STRICT_MEMORY;
 
 // This structure is necessary for the enclave to load correctly.
 #[no_mangle]
@@ -58,10 +61,17 @@ extern "C" fn new_keypair(params_vtl0: *const NewKeypairParams) -> HRESULT {
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let params_vtl1 = if is_valid_vtl0(params_vtl0, size_of::<NewKeypairParams>()) {
-        unsafe { *params_vtl0 }
+    let params_vtl1 = if cfg!(feature = "strict_memory") {
+        match copy_into_enclave(params_vtl0) {
+            Ok(v) => v,
+            Err(e) => return e.into(),
+        }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0(params_vtl0, size_of::<NewKeypairParams>()) {
+            unsafe { *params_vtl0 }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     };
 
     // Next, the public key buffer also lives in vtl0, so it needs to be
@@ -69,20 +79,27 @@ extern "C" fn new_keypair(params_vtl0: *const NewKeypairParams) -> HRESULT {
     let mut public_key_blob = Vec::new();
     public_key_blob.resize(ECDH_256_PUBLIC_BLOB_SIZE, 0u8);
 
-    if is_valid_vtl0(
-        (&params_vtl1).public_key_blob as *const u8 as *const _,
-        ECDH_256_PUBLIC_BLOB_SIZE,
-    ) {
-        unsafe {
-            public_key_blob
-                .as_mut_slice()
-                .copy_from_slice(core::slice::from_raw_parts(
-                    params_vtl1.public_key_blob,
-                    ECDH_256_PUBLIC_BLOB_SIZE,
-                ));
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_into_enclave(public_key_blob.as_mut_slice(), params_vtl1.public_key_blob()) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0(
+            (&params_vtl1).public_key_blob() as *const _,
+            ECDH_256_PUBLIC_BLOB_SIZE,
+        ) {
+            unsafe {
+                public_key_blob
+                    .as_mut_slice()
+                    .copy_from_slice(core::slice::from_raw_parts(
+                        params_vtl1.public_key_blob(),
+                        ECDH_256_PUBLIC_BLOB_SIZE,
+                    ));
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // Finally, we can call the internal function that only operates on
@@ -99,9 +116,14 @@ extern "C" fn generate_report(params_vtl0: *mut GenerateReportParams) -> HRESULT
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let params_vtl1 = unsafe {
+    let mut params_vtl1 = if cfg!(feature = "strict_memory") {
+        match copy_into_enclave(params_vtl0) {
+            Ok(v) => v,
+            Err(e) => return e.into(),
+        }
+    } else {
         if is_valid_vtl0(params_vtl0, size_of::<GenerateReportParams>()) {
-            *params_vtl0.clone()
+            unsafe { *params_vtl0 }
         } else {
             return EnclaveError::invalid_arg().into();
         }
@@ -112,9 +134,9 @@ extern "C" fn generate_report(params_vtl0: *mut GenerateReportParams) -> HRESULT
     // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
     // because if it were checked in the vtl0 struct, an attacker could change it
     // after it is checked but before it is used.
-    if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
-        return EnclaveError::invalid_arg().into();
-    }
+    // if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
+    //     return EnclaveError::invalid_arg().into();
+    // }
 
     // The internal function operated only on safe Rust objects. Any unsafe code
     // is in the FFI function like this one, or in a wrapper function for bcrypt
@@ -127,32 +149,54 @@ extern "C" fn generate_report(params_vtl0: *mut GenerateReportParams) -> HRESULT
     // Once we have the report vector, we call the vtl0 allocation callback
     // and validate that the pointer we get back is enclave-external before copying the
     // data out to it.
-    let invocation = unsafe {
-        EnclaveRoutineInvocation::new(
-            params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
-            report.len() as *const _,
-        )
-    };
-    let allocation: *mut u8 = match call_enclave(invocation, true) {
-        Ok(v) => v as *mut u8,
+    // let invocation = unsafe {
+    //     EnclaveRoutineInvocation::new(
+    //         params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
+    //         report.len() as *const _,
+    //     )
+    // };
+    // let allocation: *mut u8 = match call_enclave(invocation, true) {
+    //     Ok(v) => v as *mut u8,
+    //     Err(e) => return e.into(),
+    // };
+
+    let allocation: *mut u8 = match params_vtl1.allocate_callback.call(report.len()) {
+        Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    if is_valid_vtl0(allocation, report.len()) {
-        unsafe {
-            let data_vtl0: &mut [u8] = core::slice::from_raw_parts_mut(allocation, report.len());
-            data_vtl0.copy_from_slice(&report);
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_out_of_enclave(allocation, &report) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0(allocation, report.len()) {
+            unsafe {
+                let data_vtl0: &mut [u8] = core::slice::from_raw_parts_mut(allocation, report.len());
+                data_vtl0.copy_from_slice(&report);
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // Finally, now that we have copied the buffer out, we set the length and pointer
     // in the vtl0 structure (which we already know is a valid allocation) so that the
     // host process can continue.
-    unsafe {
-        (*params_vtl0).report_size = report.len();
-        (*params_vtl0).report = allocation;
+    if cfg!(feature = "strict_memory") {
+        params_vtl1.report_size = report.len();
+        params_vtl1.set_report(allocation);
+
+        match copy_out_of_enclave(params_vtl0, &params_vtl1) {
+            Err(e) => return e.into(),
+            _ => {}
+        }
+    } else {
+        unsafe {
+            (*params_vtl0).report_size = report.len();
+            (*params_vtl0).set_report(allocation);
+        }
     }
 
     S_OK
@@ -164,10 +208,17 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let params_vtl1 = if is_valid_vtl0(params_vtl0, size_of::<DecryptDataParams>()) {
-        unsafe { *params_vtl0.clone() }
+    let mut params_vtl1 = if cfg!(feature = "strict_memory") {
+        match copy_into_enclave(params_vtl0) {
+            Ok(v) => v,
+            Err(e) => return e.into(),
+        }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0(params_vtl0, size_of::<DecryptDataParams>()) {
+            unsafe { *params_vtl0.clone() }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     };
 
     // Next, the callback pointer in the structure needs to be validated, otherwise
@@ -175,26 +226,33 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
     // because if it were checked in the vtl0 struct, an attacker could change it
     // after it is checked but before it is used.
-    if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
-        return EnclaveError::invalid_arg().into();
-    }
+    // if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
+    //     return EnclaveError::invalid_arg().into();
+    // }
 
     // The encrypted data buffer also lives in vtl0, so it needs to be
     // validated and copied into vtl1 as well.
     let mut encrypted_data: Vec<u8> = Vec::new();
     encrypted_data.resize(params_vtl1.encrypted_size, 0u8);
 
-    if is_valid_vtl0((&params_vtl1).encrypted_data, (&params_vtl1).encrypted_size) {
-        unsafe {
-            encrypted_data
-                .as_mut_slice()
-                .copy_from_slice(core::slice::from_raw_parts(
-                    params_vtl1.encrypted_data,
-                    params_vtl1.encrypted_size,
-                ));
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_into_enclave(&mut encrypted_data, params_vtl1.encrypted_data()) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0((&params_vtl1).encrypted_data(), (&params_vtl1).encrypted_size) {
+            unsafe {
+                encrypted_data
+                    .as_mut_slice()
+                    .copy_from_slice(core::slice::from_raw_parts(
+                        params_vtl1.encrypted_data(),
+                        params_vtl1.encrypted_size,
+                    ));
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // The initialization vector buffer also lives in vtl0, so it needs to be
@@ -202,16 +260,23 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     let mut iv: Vec<u8> = Vec::new();
     iv.resize(params_vtl1.iv_size, 0u8);
 
-    if is_valid_vtl0((&params_vtl1).iv, (&params_vtl1).iv_size) {
-        unsafe {
-            iv.as_mut_slice()
-                .copy_from_slice(core::slice::from_raw_parts(
-                    params_vtl1.iv,
-                    params_vtl1.iv_size,
-                ));
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_into_enclave(iv.as_mut_slice(), params_vtl1.iv()) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0((&params_vtl1).iv(), (&params_vtl1).iv_size) {
+            unsafe {
+                iv.as_mut_slice()
+                    .copy_from_slice(core::slice::from_raw_parts(
+                        params_vtl1.iv(),
+                        params_vtl1.iv_size,
+                    ));
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // The authentication tag buffer also lives in vtl0, so it needs to be
@@ -219,16 +284,23 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     let mut tag: Vec<u8> = Vec::new();
     tag.resize(params_vtl1.tag_size, 0u8);
 
-    if is_valid_vtl0((&params_vtl1).tag, (&params_vtl1).tag_size) {
-        unsafe {
-            tag.as_mut_slice()
-                .copy_from_slice(core::slice::from_raw_parts(
-                    params_vtl1.tag,
-                    params_vtl1.tag_size,
-                ));
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_into_enclave(tag.as_mut_slice(), params_vtl1.tag()) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0((&params_vtl1).tag(), (&params_vtl1).tag_size) {
+            unsafe {
+                tag.as_mut_slice()
+                    .copy_from_slice(core::slice::from_raw_parts(
+                        params_vtl1.tag(),
+                        params_vtl1.tag_size,
+                    ));
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // The internal function operated only on safe Rust objects. Any unsafe code
@@ -242,33 +314,55 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     // Once we have the plaintext vector, we call the vtl0 allocation callback
     // and validate that the pointer we get back is valid before copying the
     // data out to it.
-    let invocation = unsafe {
-        EnclaveRoutineInvocation::new(
-            params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
-            decrypted_data.len() as *const _,
-        )
-    };
-    let allocation: *mut u8 = match call_enclave(invocation, true) {
-        Ok(v) => v as *mut u8,
+    // let invocation = unsafe {
+    //     EnclaveRoutineInvocation::new(
+    //         params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
+    //         decrypted_data.len() as *const _,
+    //     )
+    // };
+    // let allocation: *mut u8 = match call_enclave(invocation, true) {
+    //     Ok(v) => v as *mut u8,
+    //     Err(e) => return e.into(),
+    // };
+
+    let allocation: *mut u8 = match params_vtl1.allocate_callback.call(decrypted_data.len()) {
+        Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    if is_valid_vtl0(allocation, decrypted_data.len()) {
-        unsafe {
-            let data_vtl0: &mut [u8] =
-                core::slice::from_raw_parts_mut(allocation, decrypted_data.len());
-            data_vtl0.copy_from_slice(&decrypted_data);
+    if cfg!(feature = "strict_memory") {
+        match copy_slice_out_of_enclave(allocation, &decrypted_data) {
+            Err(e) => return e.into(),
+            _ => {}
         }
     } else {
-        return EnclaveError::invalid_arg().into();
+        if is_valid_vtl0(allocation, decrypted_data.len()) {
+            unsafe {
+                let data_vtl0: &mut [u8] =
+                    core::slice::from_raw_parts_mut(allocation, decrypted_data.len());
+                data_vtl0.copy_from_slice(&decrypted_data);
+            }
+        } else {
+            return EnclaveError::invalid_arg().into();
+        }
     }
 
     // Finally, now that we have copied the buffer out, we set the length and pointer
     // in the vtl0 structure (which we already know is a valid allocation) so that the
     // host process can continue.
-    unsafe {
-        (*params_vtl0).decrypted_size = decrypted_data.len();
-        (*params_vtl0).decrypted_data = allocation;
+    if cfg!(feature = "strict_memory") {
+        params_vtl1.decrypted_size = decrypted_data.len();
+        params_vtl1.set_decrypted_data(allocation);
+        
+        match copy_out_of_enclave(params_vtl0, &params_vtl1) {
+            Err(e) => return e.into(),
+            _ => {}
+        }
+    } else {
+        unsafe {
+            (*params_vtl0).decrypted_size = decrypted_data.len();
+            (*params_vtl0).set_decrypted_data(allocation);
+        }
     }
 
     S_OK

--- a/sample/src/ffi.rs
+++ b/sample/src/ffi.rs
@@ -5,10 +5,10 @@ use crate::{
 };
 use alloc::vec::Vec;
 use hex_literal::hex;
-use vbs_enclave::error::{EnclaveError, HRESULT, S_OK};
-use vbs_enclave::is_valid_vtl0;
+use vbs_enclave::error::{HRESULT, S_OK};
 use vbs_enclave::winenclave::{
-    copy_into_enclave, copy_out_of_enclave, copy_slice_into_enclave, copy_slice_out_of_enclave, ImageEnclaveConfig, IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE, IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE
+    copy_into_enclave, copy_out_of_enclave, copy_slice_into_enclave, copy_slice_out_of_enclave,
+    ImageEnclaveConfig, IMAGE_ENCLAVE_FLAG_PRIMARY_IMAGE, IMAGE_ENCLAVE_MINIMUM_CONFIG_SIZE,
 };
 
 // You should only enable debug in debug builds, or it can allow someone to
@@ -61,17 +61,9 @@ extern "C" fn new_keypair(params_vtl0: *const NewKeypairParams) -> HRESULT {
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let params_vtl1 = if cfg!(feature = "strict_memory") {
-        match copy_into_enclave(params_vtl0) {
-            Ok(v) => v,
-            Err(e) => return e.into(),
-        }
-    } else {
-        if is_valid_vtl0(params_vtl0, size_of::<NewKeypairParams>()) {
-            unsafe { *params_vtl0 }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    let params_vtl1 = match copy_into_enclave(params_vtl0) {
+        Ok(v) => v,
+        Err(e) => return e.into(),
     };
 
     // Next, the public key buffer also lives in vtl0, so it needs to be
@@ -79,27 +71,12 @@ extern "C" fn new_keypair(params_vtl0: *const NewKeypairParams) -> HRESULT {
     let mut public_key_blob = Vec::new();
     public_key_blob.resize(ECDH_256_PUBLIC_BLOB_SIZE, 0u8);
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_into_enclave(public_key_blob.as_mut_slice(), params_vtl1.public_key_blob()) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0(
-            (&params_vtl1).public_key_blob() as *const _,
-            ECDH_256_PUBLIC_BLOB_SIZE,
-        ) {
-            unsafe {
-                public_key_blob
-                    .as_mut_slice()
-                    .copy_from_slice(core::slice::from_raw_parts(
-                        params_vtl1.public_key_blob(),
-                        ECDH_256_PUBLIC_BLOB_SIZE,
-                    ));
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_into_enclave(
+        public_key_blob.as_mut_slice(),
+        params_vtl1.public_key_blob(),
+    ) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // Finally, we can call the internal function that only operates on
@@ -116,27 +93,10 @@ extern "C" fn generate_report(params_vtl0: *mut GenerateReportParams) -> HRESULT
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let mut params_vtl1 = if cfg!(feature = "strict_memory") {
-        match copy_into_enclave(params_vtl0) {
-            Ok(v) => v,
-            Err(e) => return e.into(),
-        }
-    } else {
-        if is_valid_vtl0(params_vtl0, size_of::<GenerateReportParams>()) {
-            unsafe { *params_vtl0 }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    let mut params_vtl1 = match copy_into_enclave(params_vtl0) {
+        Ok(v) => v,
+        Err(e) => return e.into(),
     };
-
-    // Next, the callback pointer in the structure needs to be validated, otherwise
-    // CallEnclave can call a function within our vtl1 enclave and that is bad.
-    // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
-    // because if it were checked in the vtl0 struct, an attacker could change it
-    // after it is checked but before it is used.
-    // if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
-    //     return EnclaveError::invalid_arg().into();
-    // }
 
     // The internal function operated only on safe Rust objects. Any unsafe code
     // is in the FFI function like this one, or in a wrapper function for bcrypt
@@ -149,54 +109,33 @@ extern "C" fn generate_report(params_vtl0: *mut GenerateReportParams) -> HRESULT
     // Once we have the report vector, we call the vtl0 allocation callback
     // and validate that the pointer we get back is enclave-external before copying the
     // data out to it.
-    // let invocation = unsafe {
-    //     EnclaveRoutineInvocation::new(
-    //         params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
-    //         report.len() as *const _,
-    //     )
-    // };
-    // let allocation: *mut u8 = match call_enclave(invocation, true) {
-    //     Ok(v) => v as *mut u8,
-    //     Err(e) => return e.into(),
-    // };
-
+    //
+    // The callback pointer in the structure needs to be validated, otherwise
+    // CallEnclave can call a function within our vtl1 enclave and that is bad.
+    // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
+    // because if it were checked in the vtl0 struct, an attacker could change it
+    // after it is checked but before it is used.
+    //
+    // However, the AllocationCallback::call function does this validation for us!
     let allocation: *mut u8 = match params_vtl1.allocate_callback.call(report.len()) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_out_of_enclave(allocation, &report) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0(allocation, report.len()) {
-            unsafe {
-                let data_vtl0: &mut [u8] = core::slice::from_raw_parts_mut(allocation, report.len());
-                data_vtl0.copy_from_slice(&report);
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_out_of_enclave(allocation, &report) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // Finally, now that we have copied the buffer out, we set the length and pointer
     // in the vtl0 structure (which we already know is a valid allocation) so that the
     // host process can continue.
-    if cfg!(feature = "strict_memory") {
-        params_vtl1.report_size = report.len();
-        params_vtl1.set_report(allocation);
+    params_vtl1.report_size = report.len();
+    params_vtl1.set_report(allocation);
 
-        match copy_out_of_enclave(params_vtl0, &params_vtl1) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        unsafe {
-            (*params_vtl0).report_size = report.len();
-            (*params_vtl0).set_report(allocation);
-        }
+    match copy_out_of_enclave(params_vtl0, &params_vtl1) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     S_OK
@@ -208,51 +147,19 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     // pointer is fully within vtl0 memory, then copy it into vtl1 memory.
     // This prevents time-of-check/time-of-use bugs that can arise if you
     // read values that are residing within vtl0.
-    let mut params_vtl1 = if cfg!(feature = "strict_memory") {
-        match copy_into_enclave(params_vtl0) {
-            Ok(v) => v,
-            Err(e) => return e.into(),
-        }
-    } else {
-        if is_valid_vtl0(params_vtl0, size_of::<DecryptDataParams>()) {
-            unsafe { *params_vtl0.clone() }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    let mut params_vtl1 = match copy_into_enclave(params_vtl0) {
+        Ok(v) => v,
+        Err(e) => return e.into(),
     };
-
-    // Next, the callback pointer in the structure needs to be validated, otherwise
-    // CallEnclave can call a function within our vtl1 enclave and that is bad.
-    // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
-    // because if it were checked in the vtl0 struct, an attacker could change it
-    // after it is checked but before it is used.
-    // if !is_valid_vtl0(params_vtl1.allocate_callback as *const c_void, 1) {
-    //     return EnclaveError::invalid_arg().into();
-    // }
 
     // The encrypted data buffer also lives in vtl0, so it needs to be
     // validated and copied into vtl1 as well.
     let mut encrypted_data: Vec<u8> = Vec::new();
     encrypted_data.resize(params_vtl1.encrypted_size, 0u8);
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_into_enclave(&mut encrypted_data, params_vtl1.encrypted_data()) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0((&params_vtl1).encrypted_data(), (&params_vtl1).encrypted_size) {
-            unsafe {
-                encrypted_data
-                    .as_mut_slice()
-                    .copy_from_slice(core::slice::from_raw_parts(
-                        params_vtl1.encrypted_data(),
-                        params_vtl1.encrypted_size,
-                    ));
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_into_enclave(&mut encrypted_data, params_vtl1.encrypted_data()) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // The initialization vector buffer also lives in vtl0, so it needs to be
@@ -260,23 +167,9 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     let mut iv: Vec<u8> = Vec::new();
     iv.resize(params_vtl1.iv_size, 0u8);
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_into_enclave(iv.as_mut_slice(), params_vtl1.iv()) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0((&params_vtl1).iv(), (&params_vtl1).iv_size) {
-            unsafe {
-                iv.as_mut_slice()
-                    .copy_from_slice(core::slice::from_raw_parts(
-                        params_vtl1.iv(),
-                        params_vtl1.iv_size,
-                    ));
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_into_enclave(iv.as_mut_slice(), params_vtl1.iv()) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // The authentication tag buffer also lives in vtl0, so it needs to be
@@ -284,23 +177,9 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     let mut tag: Vec<u8> = Vec::new();
     tag.resize(params_vtl1.tag_size, 0u8);
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_into_enclave(tag.as_mut_slice(), params_vtl1.tag()) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0((&params_vtl1).tag(), (&params_vtl1).tag_size) {
-            unsafe {
-                tag.as_mut_slice()
-                    .copy_from_slice(core::slice::from_raw_parts(
-                        params_vtl1.tag(),
-                        params_vtl1.tag_size,
-                    ));
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_into_enclave(tag.as_mut_slice(), params_vtl1.tag()) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // The internal function operated only on safe Rust objects. Any unsafe code
@@ -314,55 +193,33 @@ extern "C" fn decrypt_data(params_vtl0: *mut DecryptDataParams) -> HRESULT {
     // Once we have the plaintext vector, we call the vtl0 allocation callback
     // and validate that the pointer we get back is valid before copying the
     // data out to it.
-    // let invocation = unsafe {
-    //     EnclaveRoutineInvocation::new(
-    //         params_vtl1.allocate_callback as LPENCLAVE_ROUTINE,
-    //         decrypted_data.len() as *const _,
-    //     )
-    // };
-    // let allocation: *mut u8 = match call_enclave(invocation, true) {
-    //     Ok(v) => v as *mut u8,
-    //     Err(e) => return e.into(),
-    // };
-
+    //
+    // The callback pointer in the structure needs to be validated, otherwise
+    // CallEnclave can call a function within our vtl1 enclave and that is bad.
+    // Note that this pointer is checked in the vtl1 struct, not the vtl0 struct,
+    // because if it were checked in the vtl0 struct, an attacker could change it
+    // after it is checked but before it is used.
+    //
+    // However, the AllocationCallback::call function does this validation for us!
     let allocation: *mut u8 = match params_vtl1.allocate_callback.call(decrypted_data.len()) {
         Ok(v) => v,
         Err(e) => return e.into(),
     };
 
-    if cfg!(feature = "strict_memory") {
-        match copy_slice_out_of_enclave(allocation, &decrypted_data) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        if is_valid_vtl0(allocation, decrypted_data.len()) {
-            unsafe {
-                let data_vtl0: &mut [u8] =
-                    core::slice::from_raw_parts_mut(allocation, decrypted_data.len());
-                data_vtl0.copy_from_slice(&decrypted_data);
-            }
-        } else {
-            return EnclaveError::invalid_arg().into();
-        }
+    match copy_slice_out_of_enclave(allocation, &decrypted_data) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     // Finally, now that we have copied the buffer out, we set the length and pointer
     // in the vtl0 structure (which we already know is a valid allocation) so that the
     // host process can continue.
-    if cfg!(feature = "strict_memory") {
-        params_vtl1.decrypted_size = decrypted_data.len();
-        params_vtl1.set_decrypted_data(allocation);
-        
-        match copy_out_of_enclave(params_vtl0, &params_vtl1) {
-            Err(e) => return e.into(),
-            _ => {}
-        }
-    } else {
-        unsafe {
-            (*params_vtl0).decrypted_size = decrypted_data.len();
-            (*params_vtl0).set_decrypted_data(allocation);
-        }
+    params_vtl1.decrypted_size = decrypted_data.len();
+    params_vtl1.set_decrypted_data(allocation);
+
+    match copy_out_of_enclave(params_vtl0, &params_vtl1) {
+        Err(e) => return e.into(),
+        _ => {}
     }
 
     S_OK

--- a/sample/src/params.rs
+++ b/sample/src/params.rs
@@ -1,29 +1,82 @@
+use vbs_enclave::enclaveapi::{call_enclave, EnclaveRoutineInvocation};
+use vbs_enclave::error::EnclaveError;
+use vbs_enclave::is_valid_vtl0;
+use vbs_enclave::types::LPENCLAVE_ROUTINE;
+
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::TryFromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
+pub struct AllocationCallback(LPENCLAVE_ROUTINE);
+
+impl AllocationCallback {
+    pub fn call(&self, size: usize) -> Result<*mut u8, EnclaveError> {
+        if !is_valid_vtl0(self.0 as *const core::ffi::c_void, 1) {
+            Err(EnclaveError::invalid_arg())
+        } else {
+            let invocation = unsafe { EnclaveRoutineInvocation::new(self.0, size as *const _) };
+            match call_enclave(invocation, true) {
+                Ok(ptr) => Ok(ptr as *mut u8),
+                Err(e) => Err(e),
+            }
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, zerocopy::TryFromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
 pub struct NewKeypairParams {
     // Only 256 is supported, because it needs to fit into the report
     pub key_size: u32,
-    pub public_key_blob: *const u8,
+    public_key_blob: usize,
+}
+
+impl NewKeypairParams {
+    pub fn public_key_blob(&self) -> *const u8 {
+        self.public_key_blob as *const u8
+    }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::TryFromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
 pub struct GenerateReportParams {
-    pub allocate_callback: extern "C" fn(usize) -> *mut u8,
+    pub allocate_callback: AllocationCallback,
     pub report_size: usize,
-    pub report: *const u8,
+    report: usize,
+}
+
+impl GenerateReportParams {
+    pub fn set_report(&mut self, report: *const u8) {
+        self.report = report as usize;
+    }
 }
 
 #[repr(C)]
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, zerocopy::TryFromBytes, zerocopy::KnownLayout, zerocopy::Immutable)]
 pub struct DecryptDataParams {
-    pub allocate_callback: extern "C" fn(usize) -> *mut u8,
+    pub allocate_callback: AllocationCallback,
     pub encrypted_size: usize,
-    pub encrypted_data: *const u8,
+    encrypted_data: usize,
     pub iv_size: usize,
-    pub iv: *const u8,
+    iv: usize,
     pub tag_size: usize,
-    pub tag: *const u8,
+    tag: usize,
     pub decrypted_size: usize,
-    pub decrypted_data: *const u8,
+    decrypted_data: usize,  /* out parameter */
+}
+
+impl DecryptDataParams {
+    pub fn encrypted_data(&self) -> *const u8 {
+        self.encrypted_data as *const u8
+    }
+
+    pub fn iv(&self) -> *const u8 {
+        self.iv as *const u8
+    }
+
+    pub fn tag(&self) -> *const u8 {
+        self.tag as *const u8
+    }
+
+    pub fn set_decrypted_data(&mut self, decrypted_data: *const u8) {
+        self.decrypted_data = decrypted_data as usize;
+    }
 }

--- a/sample/src/params.rs
+++ b/sample/src/params.rs
@@ -60,7 +60,7 @@ pub struct DecryptDataParams {
     pub tag_size: usize,
     tag: usize,
     pub decrypted_size: usize,
-    decrypted_data: usize,  /* out parameter */
+    decrypted_data: usize, /* out parameter */
 }
 
 impl DecryptDataParams {

--- a/src/winenclave.rs
+++ b/src/winenclave.rs
@@ -2,10 +2,10 @@ use core::mem::{offset_of, MaybeUninit};
 
 use alloc::vec::Vec;
 
-use windows_sys::Win32::System::Environment::{
+use windows_sys::{core::HRESULT, Win32::{Foundation::BOOL, System::Environment::{
     EnclaveGetAttestationReport, EnclaveGetEnclaveInformation, EnclaveSealData, EnclaveUnsealData,
-    ENCLAVE_IDENTITY, ENCLAVE_INFORMATION, ENCLAVE_REPORT_DATA_LENGTH,
-};
+    ENCLAVE_IDENTITY, ENCLAVE_INFORMATION, ENCLAVE_REPORT_DATA_LENGTH
+}}};
 
 use crate::error::{check_hr, EnclaveError};
 
@@ -22,6 +22,9 @@ pub const ENCLAVE_FLAG_FULL_DEBUG_ENABLED: u32 = 0x0000_0001;
 pub const ENCLAVE_FLAG_DYNAMIC_DEBUG_ENABLED: u32 = 0x0000_0002;
 
 pub const ENCLAVE_FLAG_DYNAMIC_DEBUG_ACTIVE: u32 = 0x0000_0004;
+
+// This isn't in windows-rs yet, so define it here for now
+pub const IMAGE_ENCLAVE_POLICY_STRICT_MEMORY: u32 = 0x0000_0002;
 
 // struct _IMAGE_ENCLAVE_CONFIG64 {
 //     DWORD Size;
@@ -226,4 +229,152 @@ pub fn unseal_data(
     check_hr(hr)?;
 
     Ok(decrypted_data)
+}
+
+// These functions aren't in windows-rs yet, so we define them here.
+#[link(name = "vertdll")]
+extern "C" {
+    fn EnclaveCopyIntoEnclave(
+        enclave_address: *mut core::ffi::c_void,
+        unsecure_address: *const core::ffi::c_void,
+        number_of_bytes: usize
+    ) -> HRESULT;
+
+    fn EnclaveCopyOutOfEnclave(
+        unsecure_address: *mut core::ffi::c_void,
+        enclave_address: *const core::ffi::c_void,
+        number_of_bytes: usize
+    ) -> HRESULT;
+
+    fn EnclaveRestrictContainingProcessAccess(
+        restrict_access: BOOL,
+        previously_restricted: *mut BOOL
+    ) -> HRESULT;
+}
+
+pub fn restrict_containing_process_access(restrict_access: bool) -> Result<bool, EnclaveError> {
+    let mut previously_restricted: BOOL = 0;
+    let hr = unsafe {
+        EnclaveRestrictContainingProcessAccess(
+            restrict_access as _,
+            &mut previously_restricted
+        )
+    };
+    check_hr(hr)?;
+
+    Ok(previously_restricted != 0)
+}
+
+pub fn copy_slice_into_enclave(
+    vtl1_dest: &mut [u8],
+    vtl0_src: *const u8
+) -> Result<(), EnclaveError> {
+    let hr = unsafe {
+        EnclaveCopyIntoEnclave(
+            vtl1_dest.as_mut_ptr() as _,
+            vtl0_src as _,
+            vtl1_dest.len()
+        )
+    };
+    check_hr(hr)?;
+
+    Ok(())
+}
+
+pub fn copy_slice_out_of_enclave(
+    vtl0_dest: *mut u8,
+    vtl1_src: &[u8]
+) -> Result<(), EnclaveError> {
+    let hr = unsafe {
+        EnclaveCopyOutOfEnclave(
+            vtl0_dest as _,
+            vtl1_src.as_ptr() as _,
+            vtl1_src.len()
+        )
+    };
+    check_hr(hr)?;
+
+    Ok(())
+}
+
+pub unsafe fn copy_into_enclave_unchecked<T: Copy>(
+    vtl0_src: *const T
+) -> Result<T, EnclaveError> {
+    let mut vtl1_buffer: Vec<u8> = Vec::new();
+    vtl1_buffer.resize(core::mem::size_of::<T>(), 0);
+
+    let hr = unsafe {
+            EnclaveCopyIntoEnclave(
+            vtl1_buffer.as_mut_ptr() as _,
+            vtl0_src as _,
+            core::mem::size_of::<T>()
+        )
+    };
+
+    check_hr(hr)?;
+
+    Ok(unsafe { *(vtl1_buffer.as_ptr() as *const T) })
+}
+
+pub unsafe fn copy_out_of_enclave_unchecked<T>(
+    vtl0_dest: *mut T,
+    vtl1_src: &T
+) -> Result<(), EnclaveError> {
+    let hr = unsafe {
+        EnclaveCopyOutOfEnclave(
+            vtl0_dest as _,
+            vtl1_src as *const T as _,
+            core::mem::size_of::<T>()
+        )
+    };
+    check_hr(hr)?;
+
+    Ok(())
+}
+
+#[cfg(feature = "zerocopy")]
+pub fn copy_into_enclave<T>(
+    vtl0_src: *const T
+) -> Result<T, EnclaveError> where
+T: zerocopy::TryFromBytes + 
+    zerocopy::KnownLayout + 
+    zerocopy::Immutable + 
+    Copy
+{
+    let mut vtl1_buffer: Vec<u8> = Vec::new();
+    vtl1_buffer.resize(core::mem::size_of::<T>(), 0);
+
+    let hr = unsafe {
+        EnclaveCopyIntoEnclave(
+            vtl1_buffer.as_mut_ptr() as _,
+            vtl0_src as _,
+            core::mem::size_of::<T>()
+        )
+    };
+    check_hr(hr)?;
+
+    match T::try_ref_from_bytes(&vtl1_buffer) {
+        Ok(v) => Ok(*v),
+        Err(_) => Err(EnclaveError::invalid_arg()),
+    }
+}
+
+#[cfg(feature = "zerocopy")]
+pub fn copy_out_of_enclave<T>(
+    vtl0_dest: *mut T,
+    vtl1_src: &T
+) -> Result<(), EnclaveError> where
+T: zerocopy::KnownLayout + 
+    zerocopy::Immutable
+{
+    let hr = unsafe {
+        EnclaveCopyOutOfEnclave(
+            vtl0_dest as _,
+            vtl1_src as *const T as _,
+            core::mem::size_of::<T>()
+        )
+    };
+    check_hr(hr)?;
+
+    Ok(())
 }

--- a/src/winenclave.rs
+++ b/src/winenclave.rs
@@ -2,10 +2,16 @@ use core::mem::{offset_of, MaybeUninit};
 
 use alloc::vec::Vec;
 
-use windows_sys::{core::HRESULT, Win32::{Foundation::BOOL, System::Environment::{
-    EnclaveGetAttestationReport, EnclaveGetEnclaveInformation, EnclaveSealData, EnclaveUnsealData,
-    ENCLAVE_IDENTITY, ENCLAVE_INFORMATION, ENCLAVE_REPORT_DATA_LENGTH
-}}};
+use windows_sys::{
+    core::HRESULT,
+    Win32::{
+        Foundation::BOOL,
+        System::Environment::{
+            EnclaveGetAttestationReport, EnclaveGetEnclaveInformation, EnclaveSealData,
+            EnclaveUnsealData, ENCLAVE_IDENTITY, ENCLAVE_INFORMATION, ENCLAVE_REPORT_DATA_LENGTH,
+        },
+    },
+};
 
 use crate::error::{check_hr, EnclaveError};
 
@@ -237,28 +243,25 @@ extern "C" {
     fn EnclaveCopyIntoEnclave(
         enclave_address: *mut core::ffi::c_void,
         unsecure_address: *const core::ffi::c_void,
-        number_of_bytes: usize
+        number_of_bytes: usize,
     ) -> HRESULT;
 
     fn EnclaveCopyOutOfEnclave(
         unsecure_address: *mut core::ffi::c_void,
         enclave_address: *const core::ffi::c_void,
-        number_of_bytes: usize
+        number_of_bytes: usize,
     ) -> HRESULT;
 
     fn EnclaveRestrictContainingProcessAccess(
         restrict_access: BOOL,
-        previously_restricted: *mut BOOL
+        previously_restricted: *mut BOOL,
     ) -> HRESULT;
 }
 
 pub fn restrict_containing_process_access(restrict_access: bool) -> Result<bool, EnclaveError> {
     let mut previously_restricted: BOOL = 0;
     let hr = unsafe {
-        EnclaveRestrictContainingProcessAccess(
-            restrict_access as _,
-            &mut previously_restricted
-        )
+        EnclaveRestrictContainingProcessAccess(restrict_access as _, &mut previously_restricted)
     };
     check_hr(hr)?;
 
@@ -267,47 +270,33 @@ pub fn restrict_containing_process_access(restrict_access: bool) -> Result<bool,
 
 pub fn copy_slice_into_enclave(
     vtl1_dest: &mut [u8],
-    vtl0_src: *const u8
+    vtl0_src: *const u8,
 ) -> Result<(), EnclaveError> {
     let hr = unsafe {
-        EnclaveCopyIntoEnclave(
-            vtl1_dest.as_mut_ptr() as _,
-            vtl0_src as _,
-            vtl1_dest.len()
-        )
+        EnclaveCopyIntoEnclave(vtl1_dest.as_mut_ptr() as _, vtl0_src as _, vtl1_dest.len())
     };
     check_hr(hr)?;
 
     Ok(())
 }
 
-pub fn copy_slice_out_of_enclave(
-    vtl0_dest: *mut u8,
-    vtl1_src: &[u8]
-) -> Result<(), EnclaveError> {
-    let hr = unsafe {
-        EnclaveCopyOutOfEnclave(
-            vtl0_dest as _,
-            vtl1_src.as_ptr() as _,
-            vtl1_src.len()
-        )
-    };
+pub fn copy_slice_out_of_enclave(vtl0_dest: *mut u8, vtl1_src: &[u8]) -> Result<(), EnclaveError> {
+    let hr =
+        unsafe { EnclaveCopyOutOfEnclave(vtl0_dest as _, vtl1_src.as_ptr() as _, vtl1_src.len()) };
     check_hr(hr)?;
 
     Ok(())
 }
 
-pub unsafe fn copy_into_enclave_unchecked<T: Copy>(
-    vtl0_src: *const T
-) -> Result<T, EnclaveError> {
+pub unsafe fn copy_into_enclave_unchecked<T: Copy>(vtl0_src: *const T) -> Result<T, EnclaveError> {
     let mut vtl1_buffer: Vec<u8> = Vec::new();
     vtl1_buffer.resize(core::mem::size_of::<T>(), 0);
 
     let hr = unsafe {
-            EnclaveCopyIntoEnclave(
+        EnclaveCopyIntoEnclave(
             vtl1_buffer.as_mut_ptr() as _,
             vtl0_src as _,
-            core::mem::size_of::<T>()
+            core::mem::size_of::<T>(),
         )
     };
 
@@ -318,13 +307,13 @@ pub unsafe fn copy_into_enclave_unchecked<T: Copy>(
 
 pub unsafe fn copy_out_of_enclave_unchecked<T>(
     vtl0_dest: *mut T,
-    vtl1_src: &T
+    vtl1_src: &T,
 ) -> Result<(), EnclaveError> {
     let hr = unsafe {
         EnclaveCopyOutOfEnclave(
             vtl0_dest as _,
             vtl1_src as *const T as _,
-            core::mem::size_of::<T>()
+            core::mem::size_of::<T>(),
         )
     };
     check_hr(hr)?;
@@ -333,13 +322,9 @@ pub unsafe fn copy_out_of_enclave_unchecked<T>(
 }
 
 #[cfg(feature = "zerocopy")]
-pub fn copy_into_enclave<T>(
-    vtl0_src: *const T
-) -> Result<T, EnclaveError> where
-T: zerocopy::TryFromBytes + 
-    zerocopy::KnownLayout + 
-    zerocopy::Immutable + 
-    Copy
+pub fn copy_into_enclave<T>(vtl0_src: *const T) -> Result<T, EnclaveError>
+where
+    T: zerocopy::TryFromBytes + zerocopy::KnownLayout + zerocopy::Immutable + Copy,
 {
     let mut vtl1_buffer: Vec<u8> = Vec::new();
     vtl1_buffer.resize(core::mem::size_of::<T>(), 0);
@@ -348,7 +333,7 @@ T: zerocopy::TryFromBytes +
         EnclaveCopyIntoEnclave(
             vtl1_buffer.as_mut_ptr() as _,
             vtl0_src as _,
-            core::mem::size_of::<T>()
+            core::mem::size_of::<T>(),
         )
     };
     check_hr(hr)?;
@@ -360,18 +345,15 @@ T: zerocopy::TryFromBytes +
 }
 
 #[cfg(feature = "zerocopy")]
-pub fn copy_out_of_enclave<T>(
-    vtl0_dest: *mut T,
-    vtl1_src: &T
-) -> Result<(), EnclaveError> where
-T: zerocopy::KnownLayout + 
-    zerocopy::Immutable
+pub fn copy_out_of_enclave<T>(vtl0_dest: *mut T, vtl1_src: &T) -> Result<(), EnclaveError>
+where
+    T: zerocopy::KnownLayout + zerocopy::Immutable,
 {
     let hr = unsafe {
         EnclaveCopyOutOfEnclave(
             vtl0_dest as _,
             vtl1_src as *const T as _,
-            core::mem::size_of::<T>()
+            core::mem::size_of::<T>(),
         )
     };
     check_hr(hr)?;


### PR DESCRIPTION
* Added the new memory accessors to `winenclave.rs`, including wrappers that convert to a given type using `zerocopy`
* Refactored the sample to use the accessors when the `strict_memory` feature is enabled
* Converted the allocation callbacks from function types to a new `AllocationCallback` structure, which implements a `call` method that ensures the function pointer is VTL0 before invoking it.